### PR TITLE
Increase height of buttons to center text

### DIFF
--- a/css/blog.scss
+++ b/css/blog.scss
@@ -21,8 +21,8 @@ h3 {
 }
 
 .btn {
-    height: 32px;
-    line-height: 30px;
+    height: 30px;
+    line-height: 28px;
     font-size: 15px;
     border-radius: 2px;
     padding: 0 15px;

--- a/css/blog.scss
+++ b/css/blog.scss
@@ -21,7 +21,7 @@ h3 {
 }
 
 .btn {
-    height: 30px;
+    height: 32px;
     line-height: 30px;
     font-size: 15px;
     border-radius: 2px;


### PR DESCRIPTION
The text is a bit off center otherwise, because of the 2px border-radius. IMO, this looks better.

*Old*
<img width="225" alt="screen shot 2017-01-22 at 11 45 12 am" src="https://cloud.githubusercontent.com/assets/2124557/22184022/45267342-e098-11e6-811e-6225e8a51d17.png">

vs.

*New*
<img width="350" alt="screen shot 2017-01-22 at 11 45 05 am" src="https://cloud.githubusercontent.com/assets/2124557/22184024/4a22eb78-e098-11e6-8148-01b93fad045f.png">
